### PR TITLE
Fix Issue #50: Replace NSIDL::download with inetc::get

### DIFF
--- a/nsis/DotNetChecker.nsh
+++ b/nsis/DotNetChecker.nsh
@@ -176,16 +176,16 @@ Function "DownloadDotNet"
 	Pop $0
 
 	DetailPrint "Beginning download of .NET Framework $1."
-	NSISDL::download $0 "${LOCAL_DOTNET_INSTALLER_LOCATION}"
+	inetc::get /caption "Downloading .NET Framework $1" /canceltext "Cancel" $0 "${LOCAL_DOTNET_INSTALLER_LOCATION}" /end
 	DetailPrint "Completed download."
 
 	Pop $0
-	${If} $0 == "cancel"
+	${If} $0 == "Cancelled"
 		Push false
 		MessageBox MB_YESNO|MB_ICONEXCLAMATION \
 		"Download canceled.  Continue Installation?" \
 		IDYES Continue IDNO Halt
-	${ElseIf} $0 != "success"
+	${ElseIf} $0 != "OK"
 		Push false
 		MessageBox MB_YESNO|MB_ICONEXCLAMATION \
 		"Download failed:$\n$0$\n$\nContinue Installation?" \


### PR DESCRIPTION
This resolves connection time-outs when accessing https download links, as detailed in issue #50.

New dependency introduced: [inetc plugin](https://github.com/DigitalMediaServer/NSIS-INetC-plugin).